### PR TITLE
Stop running Spark as a deamon when client mode is on.

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -78,10 +78,10 @@ spark_validate() {
 
     # Validate spark mode
     case "$SPARK_MODE" in
-        master|worker)
+        master|worker|client)
         ;;
         *)
-            print_validation_error "Invalid mode $SPARK_MODE. Supported types are 'master/worker'"
+            print_validation_error "Invalid mode $SPARK_MODE. Supported types are 'master/worker/client'"
     esac
 
     # Validate worker node inputs

--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
@@ -19,14 +19,19 @@ if [ "$SPARK_MODE" == "master" ]; then
     EXEC=$(command -v start-master.sh)
     ARGS=()
     info "** Starting Spark in master mode **"
+elif [ "$SPARK_MODE" == "client" ]; then
+    info "** Starting Spark in client mode **"
 else
     # Worker constants
     EXEC=$(command -v start-slave.sh)
     ARGS=("$SPARK_MASTER_URL")
     info "** Starting Spark in worker mode **"
 fi
-if am_i_root; then
-    exec gosu "$SPARK_DAEMON_USER" "$EXEC" "${ARGS[@]-}"
-else
-    exec "$EXEC" "${ARGS[@]-}"
+
+if [ "$SPARK_MODE" != "client" ]; then
+    if am_i_root; then
+        exec gosu "$SPARK_DAEMON_USER" "$EXEC" "${ARGS[@]-}"
+    else
+        exec "$EXEC" "${ARGS[@]-}"
+    fi
 fi

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ docker run -d --name spark \
 
 Available variables:
 
-* SPARK_MODE: Cluster mode starting Spark. Valid values: *master*, *worker*. Default: **master**
+* SPARK_MODE: Cluster mode starting Spark. Valid values: *master*, *worker*, *client*. Default: **master**
 * SPARK_MASTER_URL: Url where the worker can find the master. Only needed when spark mode is *worker*. Default: **spark://spark-master:7077**
 * SPARK_RPC_AUTHENTICATION_ENABLED: Enable RPC authentication. Default: **no**
 * SPARK_RPC_AUTHENTICATION_SECRET: The secret key used for RPC authentication. No defaults.
@@ -209,6 +209,27 @@ $ pyspark
 >>> sc._gateway.jvm.org.apache.hadoop.util.VersionInfo.getVersion()
 '2.7.4'
 ```
+
+### Submitting applications
+
+When using the *client* mode, Spark will not run as a daemon. You can then use `spark-submit` to run jobs on a cluster.
+
+```yaml
+environment:
+  - SPARK_MODE=client
+ports:
+  - '4040:4040'
+command:
+  - spark-submit
+  - --class
+  - org.apache.spark.examples.SparkPi
+  - --master
+  - spark://spark:7077
+  - https://repo1.maven.org/maven2/org/apache/spark/spark-examples_2.10/1.1.1/spark-examples_2.10-1.1.1.jar
+  - "1000"
+```
+
+Note: If using `--deploy-mode cluster` the master to where you are trying to connect needs to be up and running. This is why using this mode with `docker-compose` will most often result in the submitted application to fail. It is best to use the default `--deploy-mode client` with `docker-compose`.
 
 # Logging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,19 @@ services:
       - SPARK_RPC_ENCRYPTION_ENABLED=no
       - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
       - SPARK_SSL_ENABLED=no
+  spark-client:
+    image: docker.io/bitnami/spark:3-debian-10
+    environment:
+      - SPARK_MODE=client
+    ports:
+      - '4040:4040'
+    command:
+      - spark-submit
+      - --deploy-mode
+      - client
+      - --class
+      - org.apache.spark.examples.SparkPi
+      - --master
+      - spark://spark:7077
+      - https://repo1.maven.org/maven2/org/apache/spark/spark-examples_2.10/1.1.1/spark-examples_2.10-1.1.1.jar
+      - "1000"


### PR DESCRIPTION
Allow using the image solely for submitting applications to other Spark clusters.

Using `--deploy-mode cluster` along with `docker-compose` will probably result in application failures, since the master needs to be up. The default deploy mode, `client` is best to be used for this particular purpose.