### PR TITLE
Add thriftserver SPARK_MODE support

### DIFF
--- a/3/debian-10/Dockerfile
+++ b/3/debian-10/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/spark/postunpack.sh
 ENV BITNAMI_APP_NAME="spark" \
-    BITNAMI_IMAGE_VERSION="3.1.2-debian-10-r55" \
+    BITNAMI_IMAGE_VERSION="3.1.2-debian-10-r56" \
     JAVA_HOME="/opt/bitnami/java" \
     LD_LIBRARY_PATH="/opt/bitnami/python/lib/:/opt/bitnami/spark/venv/lib/python3.6/site-packages/numpy.libs/:$LD_LIBRARY_PATH" \
     LIBNSS_WRAPPER_PATH="/opt/bitnami/common/lib/libnss_wrapper.so" \

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -232,12 +232,10 @@ spark_enable_metrics() {
 spark_set_driver_host() {
     info "Configuring driver host..."
 
-    if [[ "${SPARK_DRIVER_HOST}" ]] ; then
-        if validate_ipv4 "${SPARK_DRIVER_HOST}" ; then
-            spark_conf_set spark.driver.host "${SPARK_DRIVER_HOST}"
-        else
-            print_validation_error "SPARK_DRIVER_HOST is not a valid ipv4 address"
-        fi
+    if validate_ipv4 "${SPARK_DRIVER_HOST}" ; then
+        spark_conf_set spark.driver.host "${SPARK_DRIVER_HOST}"
+    else
+        print_validation_error "SPARK_DRIVER_HOST is not a valid ipv4 address"
     fi
 }
 
@@ -382,5 +380,9 @@ spark_initialize() {
         fi
     else
         info "Detected mounted configuration file..."
+    fi
+
+    if [[ "${SPARK_DRIVER_HOST}" ]] ; then
+        spark_set_driver_host()
     fi
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -383,5 +383,4 @@ spark_initialize() {
     else
         info "Detected mounted configuration file..."
     fi
-
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -218,7 +218,7 @@ spark_enable_metrics() {
 }
 
 ########################
-# Enable metrics
+# Set driver host to a custom value
 # Globals:
 #   SPARK_*
 # Arguments:
@@ -236,6 +236,23 @@ spark_set_driver_host() {
             print_validation_error "SPARK_DRIVER_HOST is not a valid ipv4 address"
         fi
     fi
+}
+
+
+########################
+# Creates an empty hive metastore with derby in-memory db
+# Globals:
+#   SPARK_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+spark_default_hive_metastore() {
+    info "Set default in-memory hive metastore"
+
+    spark_conf_set "spark.hadoop.javax.jdo.option.ConnectionURL" "jdbc:derby:memory:myInMemDB;create=true"
+    spark_conf_set "spark.sql.warehouse.dir" "/tmp"
 }
 
 ########################
@@ -350,6 +367,11 @@ spark_initialize() {
         # Enable metrics
         if is_boolean_yes "$SPARK_METRICS_ENABLED"; then
             spark_enable_metrics
+        fi
+
+        # initialize empty metastore by default for thriftserver
+        if [ "$SPARK_MODE" == "thriftserver" ]; then
+            spark_default_hive_metastore
         fi
     else
         info "Detected mounted configuration file..."

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -46,7 +46,7 @@ export SPARK_RPC_ENCRYPTION_ENABLED="${SPARK_RPC_ENCRYPTION_ENABLED:-no}"
 export SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED="${SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED:-no}"
 
 #  Networking
-export SPARK_DRIVER_HOST="${SPARK_DRIVER_HOST:-}
+export SPARK_DRIVER_HOST="${SPARK_DRIVER_HOST:-}"
 
 # SSL
 export SPARK_SSL_ENABLED="${SPARK_SSL_ENABLED:-no}"
@@ -254,12 +254,12 @@ spark_set_driver_host() {
 spark_default_hive_metastore() {
     info "Set default in-memory hive metastore"
 
-    metastore_dir="/opt/bitnami/spark/metastore"
-    ensure_dir_exists "$metastore_dir"
-    am_i_root && chown "$SPARK_DAEMON_USER:$SPARK_DAEMON_GROUP" "$metastore_dir"
+    warehouse_dir="/opt/bitnami/spark/work/warehouse"
+    ensure_dir_exists "${warehouse_dir}"
+    am_i_root && chown "$SPARK_DAEMON_USER:$SPARK_DAEMON_GROUP" "${warehouse_dir}"
 
     spark_conf_set "spark.hadoop.javax.jdo.option.ConnectionURL" "jdbc:derby:memory:myInMemDB;create=true"
-    spark_conf_set "spark.sql.warehouse.dir" "${metastore_dor}"
+    spark_conf_set "spark.sql.warehouse.dir" "${warehouse_dir}"
 }
 
 ########################

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -146,7 +146,7 @@ spark_validate() {
 #########################
 spark_generate_conf_file() {
     info "Generating Spark configuration file..."
-    mv "${SPARK_CONFDIR}/spark-defaults.conf.template" "${SPARK_CONFDIR}/spark-defaults.conf"
+    cp "${SPARK_CONFDIR}/spark-defaults.conf.template" "${SPARK_CONFDIR}/spark-defaults.conf"
 }
 
 ########################

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -242,7 +242,7 @@ spark_set_driver_host() {
 ########################
 # Creates an empty hive metastore with derby in-memory db
 # Globals:
-#   SPARK_*
+#   None
 # Arguments:
 #   None
 # Returns:

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -84,10 +84,10 @@ spark_validate() {
 
     # Validate spark mode
     case "$SPARK_MODE" in
-    master | worker) ;;
+    master | worker | thriftserver ) ;;
 
     *)
-        print_validation_error "Invalid mode $SPARK_MODE. Supported types are 'master/worker'"
+        print_validation_error "Invalid mode $SPARK_MODE. Supported types are 'master/worker/thriftserver'"
         ;;
     esac
 
@@ -97,7 +97,7 @@ spark_validate() {
     fi
 
     # Validate worker node inputs
-    if [[ "$SPARK_MODE" == "worker" ]]; then
+    if [[ "$SPARK_MODE" != "master" ]]; then
         if [[ -z "$SPARK_MASTER_URL" ]]; then
             print_validation_error "For worker nodes you need to specify the SPARK_MASTER_URL"
         fi
@@ -218,6 +218,27 @@ spark_enable_metrics() {
 }
 
 ########################
+# Enable metrics
+# Globals:
+#   SPARK_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+spark_set_driver_host() {
+    info "Configuring driver host..."
+
+    if [[ -z "${SPARK_DRIVER_HOST}" ]] ; then
+        if validate_ipv4 "${SPARK_DRIVER_HOST}" ; then
+            spark_conf_set spark.driver.host "${SPARK_DRIVER_HOST}"
+        else
+            print_validation_error "SPARK_DRIVER_HOST is not a valid ipv4 address"
+        fi
+    fi
+}
+
+########################
 # Configure Spark SSL (https://spark.apache.org/docs/latest/security.html#ssl-configuration)
 # Globals:
 #   SPARK_*
@@ -333,4 +354,6 @@ spark_initialize() {
     else
         info "Detected mounted configuration file..."
     fi
+
+
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libspark.sh
@@ -232,11 +232,7 @@ spark_enable_metrics() {
 spark_set_driver_host() {
     info "Configuring driver host..."
 
-    if validate_ipv4 "${SPARK_DRIVER_HOST}" ; then
-        spark_conf_set spark.driver.host "${SPARK_DRIVER_HOST}"
-    else
-        print_validation_error "SPARK_DRIVER_HOST is not a valid ipv4 address"
-    fi
+    spark_conf_set spark.driver.host "${SPARK_DRIVER_HOST}"
 }
 
 
@@ -250,7 +246,7 @@ spark_set_driver_host() {
 #   None
 #########################
 spark_default_hive_metastore() {
-    info "Set default in-memory hive metastore"
+    info "Configuring default in-memory hive metastore..."
 
     warehouse_dir="/opt/bitnami/spark/work/warehouse"
     ensure_dir_exists "${warehouse_dir}"
@@ -383,6 +379,6 @@ spark_initialize() {
     fi
 
     if [[ "${SPARK_DRIVER_HOST}" ]] ; then
-        spark_set_driver_host()
+        spark_set_driver_host
     fi
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
@@ -19,6 +19,11 @@ if [ "$SPARK_MODE" == "master" ]; then
     EXEC=$(command -v start-master.sh)
     ARGS=()
     info "** Starting Spark in master mode **"
+elif [ "$SPARK_MODE" == "thriftserver" ]; then
+    # Master constants
+    EXEC=$(command -v start-thriftserver.sh)
+    ARGS=()
+    info "** Starting Spark Thriftserver **"
 else
     # Worker constants
     EXEC=$(command -v start-slave.sh)

--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
@@ -22,7 +22,7 @@ if [ "$SPARK_MODE" == "master" ]; then
 elif [ "$SPARK_MODE" == "thriftserver" ]; then
     # Thriftserver constants
     EXEC=$(command -v start-thriftserver.sh)
-    ARGS=("-master" "$SPARK_MASTER_URL")
+    ARGS=("--master" "$SPARK_MASTER_URL")
     info "** Starting Spark Thriftserver **"
 else
     # Worker constants

--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
@@ -20,7 +20,7 @@ if [ "$SPARK_MODE" == "master" ]; then
     ARGS=()
     info "** Starting Spark in master mode **"
 elif [ "$SPARK_MODE" == "thriftserver" ]; then
-    # Master constants
+    # Thriftserver constants
     EXEC=$(command -v start-thriftserver.sh)
     ARGS=()
     info "** Starting Spark Thriftserver **"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`3`, `3-debian-10`, `3.1.2`, `3.1.2-debian-10-r55`, `latest` (3/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-spark/blob/3.1.2-debian-10-r55/3/debian-10/Dockerfile)
+* [`3`, `3-debian-10`, `3.1.2`, `3.1.2-debian-10-r56`, `latest` (3/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-spark/blob/3.1.2-debian-10-r56/3/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/spark GitHub repo](https://github.com/bitnami/bitnami-docker-spark).
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ docker run -d --name spark \
 
 Available variables:
 
-* SPARK_MODE: Cluster mode starting Spark. Valid values: *master*, *worker*. Default: **master**
+* SPARK_MODE: Cluster mode starting Spark. Valid values: *master*, *worker* or *thriftserver*. Default: **master**
 * SPARK_MASTER_URL: Url where the worker can find the master. Only needed when spark mode is *worker*. Default: **spark://spark-master:7077**
 * SPARK_RPC_AUTHENTICATION_ENABLED: Enable RPC authentication. Default: **no**
 * SPARK_RPC_AUTHENTICATION_SECRET: The secret key used for RPC authentication. No defaults.
@@ -112,6 +112,7 @@ Available variables:
 * SPARK_SSL_PROTOCOL: TLS protocol to use. Default: **TLSv1.2**
 * SPARK_DAEMON_USER: Spark system user when the container is started as root. Default: **spark**
 * SPARK_DAEMON_GROUP: Spark system group when the container is started as root. Default: **spark**
+* SPARK_DRIVER_HOST: Internal IPv4 address of the container. No defaults.
 
 More environment variables natively supported by Spark can be found [at the official documentation](https://spark.apache.org/docs/latest/spark-standalone.html#cluster-launch-scripts).
 For example, you could still use `SPARK_WORKER_CORES` or `SPARK_WORKER_MEMORY` to configure the number of cores and the amount of memory to be used by a worker machine.


### PR DESCRIPTION
**Description of the change**

In our environments, we tend to deploy Spark Thriftserver for SQL access. To this, I added `SPARK_MODE=thriftserver` that executes `start-thriftserver.sh` from `run.sh`.  In `thriftserver` mode during the startup the container initializes an empty hive metastore. 

As Thriftserver runs only in clean deployment mode, I added a new environment variable `SPARK_DRIVER_HOST` to make it possible to run inside Kubernetes. With this environment variable, Kubernetes deployments can pass the podIp to use that for internal communication between the driver and workers. 

**Benefits**

From now you can easily create a Spark SQL environment with internal or external metastore, accessible from JDBC/ODBC tools such as beeline, Tableau, or others. 

**Possible drawbacks**

Not 
**Applicable issues**

No issue was raised. 

