### PR TITLE
start-slave.sh was deprecated, use worker instead

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/run.sh
@@ -21,7 +21,7 @@ if [ "$SPARK_MODE" == "master" ]; then
     info "** Starting Spark in master mode **"
 else
     # Worker constants
-    EXEC=$(command -v start-slave.sh)
+    EXEC=$(command -v start-worker.sh)
     ARGS=("$SPARK_MASTER_URL")
     info "** Starting Spark in worker mode **"
 fi


### PR DESCRIPTION
The current `run.sh` gives a deprecation warning:


```
spark-worker-2_1        |  05:43:15.13 INFO  ==> ** Spark setup finished! **
spark-worker-2_1        |  05:43:15.14 INFO  ==> ** Starting Spark in worker mode **
spark-worker-2_1        | This script is deprecated, use start-worker.sh
spark-worker-2_1        | starting org.apache.spark.deploy.worker.Worker, logging to /opt/bitnami/spark/logs/spark--org.apache.spark.deploy.worker.Worker-1-7f9898398a64.out
spark-worker-2_1        | Spark Command: /opt/bitnami/java/bin/java -cp /opt/bitnami/spark/conf/:/opt/bitnami/spark/jars/* -Xmx1g org.apache.spark.deploy.worker.Worker --webui-port 8081 spark://spark:7077```
```
it supposed to use `start-worker.sh` instead of `start-slave.sh`