### PR TITLE
Use spark tmp for ivy

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
@@ -36,7 +36,7 @@ case "$1" in
     CMD=(
         "/opt/bitnami/spark/bin/spark-submit"
         --master "${SPARK_MASTER_URL}"
-        --conf "spark.jars.ivy=/tmp/.ivy"
+        --conf "spark.jars.ivy=/opt/bitnami/spark/tmp/.ivy"
         --deploy-mode client
         "$@"
     )


### PR DESCRIPTION
There is already ``/opt/bitnami/spark/tmp`` as temporary folder, ivy should use it as well, this make easier volumes configuration (especially for read-only container).

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
